### PR TITLE
Narrow screen fix

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -22,15 +22,15 @@
       {{ end }}
     {{ end }}
     <br>
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-between flex-col sm:flex-row">
 
-        <p>
+        <p class="pr-4 pb-2">
             {{ with resources.Get "images/logos/eu.svg" }}
                 <img src="{{ .RelPermalink }}" alt="European Commission Logo"/>
             {{ end }}
         </p>
 
-        <p class="text-sm text-neutral-500 dark:text-neutral-400">
+        <p class="text-sm text-neutral-500 dark:text-neutral-400 px-4 pb-2">
             This project has received funding from the European Union’s Horizon 
             Europe Programme under GA 101129744 — EVERSE — <a href="https://ec.europa.eu/info/funding-tenders/opportunities/portal/screen/opportunities/topic-details/horizon-infra-2023-eosc-01-02"><b>HORIZON-INFRA-2023-EOSC-01-02</b></a>
         </p>
@@ -39,7 +39,7 @@
   
         {{/* Copyright */}}
         {{ if .Site.Params.footer.showCopyright | default true }}
-        <p class="text-sm text-neutral-500 dark:text-neutral-400">
+        <p class="text-sm text-neutral-500 dark:text-neutral-400 pl-4 pb-2">
             {{- with replace .Site.Params.copyright "{ year }" now.Year  }}
             {{ . | emojify | markdownify }}
             {{- else }}

--- a/layouts/shortcodes/column-content.html
+++ b/layouts/shortcodes/column-content.html
@@ -1,6 +1,6 @@
-<div class="flex flex-row justify-evenly ">
+<div class="flex justify-evenly flex-col sm:flex-row">
     {{- range split .Inner "<--->" }}
-      <div class="px-8">
+      <div class="p-4">
         {{ if strings.Contains . "<figure >" }}
           {{ . | safeHTML -}}
         {{ else }}

--- a/layouts/shortcodes/flex-content.html
+++ b/layouts/shortcodes/flex-content.html
@@ -1,6 +1,6 @@
-<div class="flex justify-evenly">
+<div class="flex justify-evenly flex-col sm:flex-row">
   {{- range split .Inner "<--->" }}
-    <div class="px-8">
+    <div class="p-4">
       {{ if strings.Contains . "<figure >" }}
         {{ . | safeHTML -}}
       {{ else }}


### PR DESCRIPTION
Fix the footer, flex-column and fixed-column layouts to allow the horizontal row to become a stacked column when the screen gets narrow. This helps a lot on a mobile device.

Also add some padding around items, so that elements don't touch each other as the screen width is adjusted.

Fixes #14.