### PR TITLE
changed broken link to RSQKit involvement

### DIFF
--- a/content/services/RSQKit.md
+++ b/content/services/RSQKit.md
@@ -10,5 +10,5 @@ The framework for research software excellence will incorporate aspects involvin
 
 By embedding the RSQkit and services into the EOSC Science Clusters, EVERSE will demonstrate improvements in the quality of research software and maximise its reuse, leading to standardised software development practices and sustainable research software. Furthermore, we will drive recognition of software and support career progress for developers, from researchers who code to Research Software Engineers (RSEs), raising their capacity to guarantee software quality.
 
-Visit the [RSQkit](https://everse.software/RSQKit/) to check out the latest comments, and [make comments and suggestions via its Editorial Board](https://everse.software/RSQKit/how_to_contribute). See also [source code of RSQkit](https://github.com/EVERSE-ResearchSoftware/RSQKit).
+Visit the [RSQkit](https://everse.software/RSQKit/) to check out the latest comments, and [make comments and suggestions via its Editorial Board](https://everse.software/RSQKit/get_involved). See also [source code of RSQkit](https://github.com/EVERSE-ResearchSoftware/RSQKit).
 


### PR DESCRIPTION
old link for getting involved with the RSQKit (editorial board) was broken.
added current "get involved" link.

let me know if the text needs to be changed too.

https://everse.software/services/rsqkit/ 